### PR TITLE
Add HTML tab in browser panel

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -71,12 +71,19 @@ var main = (function ($) {
             }
         }, defaultCodeMirrorOptions));
 
+        window.htmlEditor = CodeMirror($('#html-editor')[0], $.extend({
+            mode: "htmlmixed",
+            readOnly: true
+        }, defaultCodeMirrorOptions));
+
         Inlet(jsEditor);
         Inlet(cssEditor);
+        Inlet(htmlEditor);
 
         fiddle.setUp(currentSavedFiddle);
 
         webFrame.setUp(currentSavedFiddle);
+        webFrame.syncHTML();
 
         self.addEditorCompletion(jsEditor, 'js');
         self.addEditorCompletion(cssEditor, 'css');

--- a/static/js/panes.js
+++ b/static/js/panes.js
@@ -100,26 +100,57 @@ Ext.onReady(function () {
             },
             {
                 region: 'east',
+                xtype: 'tabpanel',
                 floatable: true,
                 split: true,
                 width: '40%',
                 minWidth: 120,
                 minHeight: 140,
-                html: '<div id="web-frame" class="web-frame"></div>',
-                tools: [
+                items: [
+                    {
+                        title: 'Browser',
+                        itemId: 'browser-tab',
+                        html: '<div id="web-frame" class="web-frame"></div>'
+                    },
+                    {
+                        title: 'HTML',
+                        itemId: 'html-tab',
+                        html: '<div id="html-editor" class="code-editor"></div>'
+                    }
+                ],
+                tbar: [
+                    {
+                        iconCls: 'fa fa-arrow-left',
+                        handler: function () {
+                            if (window.webFrame && window.webFrame.back) {
+                                window.webFrame.back();
+                            }
+                        }
+                    },
+                    {
+                        iconCls: 'fa fa-arrow-right',
+                        handler: function () {
+                            if (window.webFrame && window.webFrame.forward) {
+                                window.webFrame.forward();
+                            }
+                        }
+                    },
                     {
                         xtype: 'textfield',
-//                    fieldLabel: 'URL',
                         allowBlank: false,
                         name: 'current_url',
-                        anchor: '95%',
-                        width: '100%',
-//                        vtype: 'url',
+                        flex: 1,
                         emptyText: 'http://cats.com'
                     }
                 ],
-//                title: '<input type="text" placeholder="www.google.com/*" /> ',
-                title: 'URL'
+                listeners: {
+                    tabchange: function (panel, newCard) {
+                        if (newCard.itemId === 'html-tab' && window.webFrame && window.webFrame.syncHTML) {
+                            window.webFrame.syncHTML();
+                        }
+                    }
+                },
+                title: 'Browser'
             }
         ]
     });

--- a/static/js/webframe.js
+++ b/static/js/webframe.js
@@ -69,14 +69,46 @@ var webFrame = (function ($) {
         frames['web-iframe'].window.location.reload();
     };
 
+    self.back = function () {
+        try {
+            frames['web-iframe'].history.back();
+        } catch (e) {
+            console.error('Unable to go back', e);
+        }
+    };
+
+    self.forward = function () {
+        try {
+            frames['web-iframe'].history.forward();
+        } catch (e) {
+            console.error('Unable to go forward', e);
+        }
+    };
+
     self.onFrameLoad = function (iframe) {
         webFrame.setUrl(webFrame.getPath(iframe.contentWindow.location.pathname) +
             iframe.contentWindow.location.search + iframe.contentWindow.location.hash);
         $('#web-iframe-loading').hide();
+        self.syncHTML();
     };
 
     self.setCSS = function (css) {
         frames['web-iframe'].window.document.getElementById('webfiddle-css').innerHTML = css;
+    };
+
+    self.getHTML = function () {
+        try {
+            return frames['web-iframe'].window.document.documentElement.outerHTML;
+        } catch (e) {
+            console.error('Unable to get HTML from iframe', e);
+            return '';
+        }
+    };
+
+    self.syncHTML = function () {
+        if (window.htmlEditor) {
+            window.htmlEditor.setValue(self.getHTML());
+        }
     };
 
 

--- a/templates/global/jsincludes.jinja2
+++ b/templates/global/jsincludes.jinja2
@@ -5,6 +5,8 @@
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/lib/codemirror.js"></script>
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/mode/javascript/javascript.js"></script>
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/mode/css/css.js"></script>
+<script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/mode/xml/xml.js"></script>
+<script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/mode/htmlmixed/htmlmixed.js"></script>
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/addon/edit/matchbrackets.js"></script>
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/addon/edit/closebrackets.js"></script>
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/addon/hint/show-hint.js"></script>


### PR DESCRIPTION
## Summary
- merge HTML viewer with browser panel in a tab layout
- add Back/Forward buttons to the browser toolbar
- expose `back` and `forward` helpers in webframe

## Testing
- `pytest -q` *(fails: command not found)*