### PR TITLE
Add HTML preview tab

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -71,6 +71,12 @@ var main = (function ($) {
             }
         }, defaultCodeMirrorOptions));
 
+        // Read-only editor to display generated HTML
+        window.htmlEditor = CodeMirror($('#html-editor')[0], $.extend({
+            mode: "htmlmixed",
+            readOnly: true
+        }, defaultCodeMirrorOptions));
+
         Inlet(jsEditor);
         Inlet(cssEditor);
 

--- a/static/js/panes.js
+++ b/static/js/panes.js
@@ -100,26 +100,49 @@ Ext.onReady(function () {
             },
             {
                 region: 'east',
+                xtype: 'tabpanel',
                 floatable: true,
                 split: true,
                 width: '40%',
                 minWidth: 120,
                 minHeight: 140,
-                html: '<div id="web-frame" class="web-frame"></div>',
-                tools: [
-                    {
-                        xtype: 'textfield',
-//                    fieldLabel: 'URL',
-                        allowBlank: false,
-                        name: 'current_url',
-                        anchor: '95%',
-                        width: '100%',
-//                        vtype: 'url',
-                        emptyText: 'http://cats.com'
+                activeTab: 0,
+                listeners: {
+                    tabchange: function(tabPanel, newCard) {
+                        if (newCard.title === 'HTML' && window.htmlEditor) {
+                            window.htmlEditor.refresh();
+                            webFrame.updateHTMLView();
+                        }
                     }
-                ],
-//                title: '<input type="text" placeholder="www.google.com/*" /> ',
-                title: 'URL'
+                },
+                items: [
+                    {
+                        title: 'Preview',
+                        layout: 'fit',
+                        items: [{
+                            xtype: 'component',
+                            html: '<div id="web-frame" class="web-frame"></div>',
+                            flex: 1
+                        }],
+                        tbar: [{
+                            xtype: 'textfield',
+                            allowBlank: false,
+                            name: 'current_url',
+                            anchor: '95%',
+                            width: '100%',
+                            emptyText: 'http://cats.com'
+                        }]
+                    },
+                    {
+                        title: 'HTML',
+                        layout: 'fit',
+                        items: [{
+                            xtype: 'component',
+                            html: '<div id="html-editor" class="code-editor"></div>',
+                            flex: 1
+                        }]
+                    }
+                ]
             }
         ]
     });

--- a/static/js/webframe.js
+++ b/static/js/webframe.js
@@ -73,10 +73,26 @@ var webFrame = (function ($) {
         webFrame.setUrl(webFrame.getPath(iframe.contentWindow.location.pathname) +
             iframe.contentWindow.location.search + iframe.contentWindow.location.hash);
         $('#web-iframe-loading').hide();
+        self.updateHTMLView();
     };
 
     self.setCSS = function (css) {
         frames['web-iframe'].window.document.getElementById('webfiddle-css').innerHTML = css;
+    };
+
+    self.getHTML = function () {
+        try {
+            return frames['web-iframe'].document.documentElement.outerHTML;
+        } catch (e) {
+            console.error('Unable to get HTML from iframe:', e);
+            return '';
+        }
+    };
+
+    self.updateHTMLView = function () {
+        if (window.htmlEditor) {
+            window.htmlEditor.setValue(self.getHTML());
+        }
     };
 
 

--- a/templates/global/jsincludes.jinja2
+++ b/templates/global/jsincludes.jinja2
@@ -5,6 +5,8 @@
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/lib/codemirror.js"></script>
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/mode/javascript/javascript.js"></script>
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/mode/css/css.js"></script>
+<script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/mode/xml/xml.js"></script>
+<script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/mode/htmlmixed/htmlmixed.js"></script>
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/addon/edit/matchbrackets.js"></script>
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/addon/edit/closebrackets.js"></script>
 <script type="text/javascript" src="{{ static_url }}/bower_components/codemirror/addon/hint/show-hint.js"></script>


### PR DESCRIPTION
## Summary
- extend codemirror includes to support HTML mode
- add an HTML tab to the east pane with toggle listener
- initialize a read-only CodeMirror for displaying HTML
- expose HTML retrieval/update helpers in webframe

## Testing
- `pytest tests/test_main_server.py::test_mirror_handler -q` *(fails: DefaultCredentialsError)*